### PR TITLE
Oauth with jwt integration is successfully added

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,11 @@
 			<artifactId>jjwt</artifactId>
 			<version>0.9.1</version>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.security.oauth.boot</groupId>
+			<artifactId>spring-security-oauth2-autoconfigure</artifactId>
+			<version>2.1.3.RELEASE</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/app/epolice/config/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/app/epolice/config/jwt/JwtAuthenticationEntryPoint.java
@@ -1,4 +1,4 @@
-package com.app.epolice.config;
+package com.app.epolice.config.jwt;
 
 import java.io.IOException;
 import java.io.Serializable;

--- a/src/main/java/com/app/epolice/config/jwt/JwtRequestFilter.java
+++ b/src/main/java/com/app/epolice/config/jwt/JwtRequestFilter.java
@@ -1,4 +1,4 @@
-package com.app.epolice.config;
+package com.app.epolice.config.jwt;
 
 import com.app.epolice.service.UserService;
 import io.jsonwebtoken.ExpiredJwtException;

--- a/src/main/java/com/app/epolice/config/jwt/JwtTokenUtil.java
+++ b/src/main/java/com/app/epolice/config/jwt/JwtTokenUtil.java
@@ -1,4 +1,4 @@
-package com.app.epolice.config;
+package com.app.epolice.config.jwt;
 
 import java.io.Serializable;
 import java.util.Date;

--- a/src/main/java/com/app/epolice/config/oAuth2/OAuthConfiguration.java
+++ b/src/main/java/com/app/epolice/config/oAuth2/OAuthConfiguration.java
@@ -1,0 +1,77 @@
+package com.app.epolice.config.oAuth2;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.config.annotation.configurers.ClientDetailsServiceConfigurer;
+import org.springframework.security.oauth2.config.annotation.web.configuration.AuthorizationServerConfigurerAdapter;
+import org.springframework.security.oauth2.config.annotation.web.configuration.EnableAuthorizationServer;
+import org.springframework.security.oauth2.config.annotation.web.configurers.AuthorizationServerEndpointsConfigurer;
+import org.springframework.security.oauth2.config.annotation.web.configurers.AuthorizationServerSecurityConfigurer;
+import org.springframework.security.oauth2.provider.token.store.JwtAccessTokenConverter;
+
+@Configuration
+@EnableAuthorizationServer
+public class OAuthConfiguration extends AuthorizationServerConfigurerAdapter {
+
+    private final AuthenticationManager authenticationManager;
+
+    private final PasswordEncoder passwordEncoder;
+
+    private final UserDetailsService userService;
+
+    @Value("${jwt.clientId:glee-o-meter}")
+    private String clientId;
+
+    @Value("${jwt.client-secret:secret}")
+    private String clientSecret;
+
+    @Value("${jwt.signing-key:123}")
+    private String jwtSigningKey;
+
+    @Value("${jwt.accessTokenValidititySeconds:43200}") // 12 hours
+    private int accessTokenValiditySeconds;
+
+    @Value("${jwt.authorizedGrantTypes:password,authorization_code,refresh_token}")
+    private String[] authorizedGrantTypes;
+
+    @Value("${jwt.refreshTokenValiditySeconds:2592000}") // 30 days
+    private int refreshTokenValiditySeconds;
+
+    public OAuthConfiguration(AuthenticationManager authenticationManager, PasswordEncoder passwordEncoder, UserDetailsService userService) {
+        this.authenticationManager = authenticationManager;
+        this.passwordEncoder = passwordEncoder;
+        this.userService = userService;
+    }
+
+    @Override
+    public void configure(ClientDetailsServiceConfigurer clients) throws Exception {
+        clients.inMemory()
+                .withClient(clientId)
+                .secret(passwordEncoder.encode(clientSecret))
+                .accessTokenValiditySeconds(accessTokenValiditySeconds)
+                .refreshTokenValiditySeconds(refreshTokenValiditySeconds)
+                .authorizedGrantTypes(authorizedGrantTypes)
+                .scopes("read", "write")
+                .resourceIds("api");
+    }
+
+    @Override
+    public void configure(final AuthorizationServerEndpointsConfigurer endpoints) {
+        endpoints
+                .accessTokenConverter(accessTokenConverter())
+                .userDetailsService(userService)
+                .authenticationManager(authenticationManager);
+    }
+
+    @Bean
+    JwtAccessTokenConverter accessTokenConverter() {
+        JwtAccessTokenConverter converter = new JwtAccessTokenConverter();
+        return converter;
+    }
+
+}
+

--- a/src/main/java/com/app/epolice/config/oAuth2/ResourceServerConfiguration.java
+++ b/src/main/java/com/app/epolice/config/oAuth2/ResourceServerConfiguration.java
@@ -1,0 +1,17 @@
+package com.app.epolice.config.oAuth2;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.config.annotation.web.configuration.EnableResourceServer;
+import org.springframework.security.oauth2.config.annotation.web.configuration.ResourceServerConfigurerAdapter;
+import org.springframework.security.oauth2.config.annotation.web.configurers.ResourceServerSecurityConfigurer;
+
+@Configuration
+@EnableResourceServer
+public class ResourceServerConfiguration extends ResourceServerConfigurerAdapter {
+
+    @Override
+    public void configure(ResourceServerSecurityConfigurer resources) {
+        resources.resourceId("api");
+    }
+
+}

--- a/src/main/java/com/app/epolice/controller/UserController.java
+++ b/src/main/java/com/app/epolice/controller/UserController.java
@@ -1,6 +1,6 @@
 package com.app.epolice.controller;
 
-import com.app.epolice.config.JwtTokenUtil;
+import com.app.epolice.config.jwt.JwtTokenUtil;
 import com.app.epolice.model.entity.crime.CrimeReport;
 import com.app.epolice.model.entity.jwt.JwtRequest;
 import com.app.epolice.model.entity.jwt.JwtResponse;
@@ -9,7 +9,6 @@ import com.app.epolice.service.UserService;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.DisabledException;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,8 +1,6 @@
 spring:
   application:
     name: e-police-system
-#server:
-#  port: 9080
 eureka:
   instance:
     prefer-ip-address: true


### PR DESCRIPTION
Oauth with jwt integration is successfully added. Now we have OAuth2.0 integrated with jwt that is providing all the stuff.

Url to hit:  http://localhost:8080/oauth/token

In postman go to Authorization section and select Basic auth and write there (client id value, and secret key value),
then go to body section and select url-form-encoded and then write there( grant_type:password, username: from your db, password: from your db).
Then click on post. 

![image](https://user-images.githubusercontent.com/31421697/142979479-58c4cc0d-0d70-4c46-8c26-9b1b26db8638.png)
![image](https://user-images.githubusercontent.com/31421697/142979509-feae3805-8bd0-4871-a393-e4596b1828c7.png)
